### PR TITLE
kubernetes-networks, task #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ minio123
  - [ ] Задание со * Настроить service для внутреннего dns сервера
 
 ## В процессе сделано:
- - создал Deployment c 3 replicas, поигрались с readinessProbe, livenessProbe 
+ - создал Deployment c 3 replicas, (maxSurge=0 maxUnavailable=0 запуски невозможен) поигрались с readinessProbe, livenessProbe (при livenessProbe.exec ксли проблемы,команда должна возвращать зачение отличное от 0) 
  - создал Service с ClusterIP
  - включил IPVS
  - поставил MetalLB
  - создал Service c LoadBalancer, сделал *
- - создал Headless Service, Ingress
+ - создал Headless Service, Ingress, сделал *
 
 ## Как запустить проект:
  - применить все манифесты. 
@@ -118,6 +118,8 @@ minio123
  - open http://172.17.255.2/web/index.html
  - для * nslookup dns-udp-svc.kube-system.svc.cluster.local  172.17.255.10
  - nslookup web-svc-cip.default.svc.cluster.local  172.17.255.10
+ - для * open dashboard https://172.17.255.2/dashboard/#/overview?namespace=default
+ - для * curl -v -H "canary-header: true" http://someserver.com/    curl -v  http://someserver.com/
 
 ## PR checklist:
  - [ ] Выставлен label с темой домашнего задания

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 # ДЗ по курсу "Инфраструктурная платформа на основе Kubernetes"
 dimpon Platform repository
 
+
+
+
 # Выполнено ДЗ №5
 
  - [ ] Основное ДЗ: Создать StatefulSet c - локальным S3 хранилищем
@@ -91,6 +94,33 @@ minio123
 ## PR checklist:
  - [ ] Выставлен label с темой домашнего задания
 
+# Выполнено ДЗ № 4
+
+ - [ ] Основное ДЗ сравнение iptables и IPVS, усановка MetalLB, развертывание Services(ClusterIP,LoadBalancer,Headless), Ingress
+ - [ ] Задание со * Настроить service для внутреннего dns сервера
+
+## В процессе сделано:
+ - создал Deployment c 3 replicas, поигрались с readinessProbe, livenessProbe 
+ - создал Service с ClusterIP
+ - включил IPVS
+ - поставил MetalLB
+ - создал Service c LoadBalancer, сделал *
+ - создал Headless Service, Ingress
+
+## Как запустить проект:
+ - применить все манифесты. 
+ - minikube ip  > ip route add 172.17.255.0/24 via <minikube ip>
+ - dashboard kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.1/aio/deploy/recommended.yaml
+ 
+
+## Как проверить работоспособность:
+ - open http://172.17.255.1/index.html
+ - open http://172.17.255.2/web/index.html
+ - для * nslookup dns-udp-svc.kube-system.svc.cluster.local  172.17.255.10
+ - nslookup web-svc-cip.default.svc.cluster.local  172.17.255.10
+
+## PR checklist:
+ - [ ] Выставлен label с темой домашнего задания
 
 # Выполнено ДЗ № 3
 

--- a/kubernetes-networks/canary/canary.yaml
+++ b/kubernetes-networks/canary/canary.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: canary
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: standard-pod-1
+  namespace: canary
+  labels:
+    app: standard
+spec:
+  containers:
+    - name: hello-app
+      image: gcr.io/google-samples/hello-app:2.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: standard-pod-2
+  namespace: canary
+  labels:
+    app: standard
+spec:
+  containers:
+    - name: hello-app
+      image: gcr.io/google-samples/hello-app:2.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: canary-pod-1
+  namespace: canary
+  labels:
+    app: canary
+spec:
+  containers:
+    - name: hello-app
+      image: gcr.io/google-samples/hello-app:2.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standard-svc
+  namespace: canary
+spec:
+  selector:
+    app: standard
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary-svc
+  namespace: canary
+spec:
+  selector:
+    app: canary
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: standard-ingress
+  namespace: canary
+spec:
+  rules:
+    - host: someserver.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: standard-svc
+              servicePort: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: canary-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: canary-header
+    nginx.ingress.kubernetes.io/canary-by-header-value: "on"
+    #nginx.ingress.kubernetes.io/canary-weight: "50"
+
+  namespace: canary
+spec:
+  rules:
+    - host: someserver.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: canary-svc
+              servicePort: 80

--- a/kubernetes-networks/coredns/dns-tcp-svc.yaml
+++ b/kubernetes-networks/coredns/dns-tcp-svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns-svc-key
+  name: dns-tcp-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dns-tcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+    - name: metrics
+      protocol: TCP
+      port: 9153
+      targetPort: 9153

--- a/kubernetes-networks/coredns/dns-udp-svc.yaml
+++ b/kubernetes-networks/coredns/dns-udp-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns-svc-key
+  name: dns-udp-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53

--- a/kubernetes-networks/dashboard/add-user.yaml
+++ b/kubernetes-networks/dashboard/add-user.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kubernetes-dashboard

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /dashboard/(.*)
+            backend:
+              serviceName: kubernetes-dashboard
+              servicePort: 443
+

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -11,8 +11,8 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: controller
+    #app.kubernetes.io/instance: ingress-nginx
+    #app.kubernetes.io/component: controller
   ports:
     - name: http
       port: 80

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -11,10 +11,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 100%
       maxSurge: 100%
-
-
   template:
     metadata:
       name: web # Название Pod

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web # Название нашего объекта Deployment
+spec:
+  replicas: 3 # Начнем с одного пода
+  selector: # Укажем, какие поды относятся к нашему Deployment:
+    matchLabels: # - это поды с меткой
+      app: web # app и ее значением web
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 100%
+
+
+  template:
+    metadata:
+      name: web # Название Pod
+      labels:
+        app: web # Метки в формате key: value
+        key1: value1
+    spec: # Описание Pod
+      containers: # Описание контейнеров внутри Pod
+        - name: web # Название контейнера
+          image: dimpon/dimpon-test-repo:2.0
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      initContainers:
+        - name: init-web-pod
+          image: busybox:1.31.0
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+        - path: /web
+          backend:
+            serviceName: web-svc
+            servicePort: 8000

--- a/kubernetes-networks/web-pod.yaml
+++ b/kubernetes-networks/web-pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1 # Версия API
+
+kind: Pod # Объект, который создаем
+metadata:
+  name: web # Название Pod
+  labels:
+    app: web # Метки в формате key: value
+    key1: value1
+spec: # Описание Pod
+  containers: # Описание контейнеров внутри Pod
+  - name: web # Название контейнера
+    image: dimpon/dimpon-test-repo:2.0
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 8000
+    livenessProbe:
+      tcpSocket: { port: 8000 }
+    volumeMounts:
+      - name: app
+        mountPath: /app
+  initContainers:
+    - name: init-web-pod
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}
+

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 4

 - [x] Основное ДЗ сравнение iptables и IPVS, усановка MetalLB, развертывание Services(ClusterIP,LoadBalancer,Headless), Ingress
 - [x] Задание со * Настроить service для внутреннего dns сервера

## В процессе сделано:
 - создал Deployment c 3 replicas, (maxSurge=0 maxUnavailable=0 запуски невозможен) поигрались с readinessProbe, livenessProbe (при livenessProbe.exec ксли проблемы,команда должна возвращать зачение отличное от 0) 
 - создал Service с ClusterIP
 - включил IPVS
 - поставил MetalLB
 - создал Service c LoadBalancer, сделал *
 - создал Headless Service, Ingress, сделал *

## Как запустить проект:
 - применить все манифесты. 
 - minikube ip  > ip route add 172.17.255.0/24 via <minikube ip>
 - dashboard kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.1/aio/deploy/recommended.yaml
 

## Как проверить работоспособность:
 - open http://172.17.255.1/index.html
 - open http://172.17.255.2/web/index.html
 - для * nslookup dns-udp-svc.kube-system.svc.cluster.local  172.17.255.10
 - nslookup web-svc-cip.default.svc.cluster.local  172.17.255.10
 - для * open dashboard https://172.17.255.2/dashboard/#/overview?namespace=default
 - для * curl -v -H "canary-header: true" http://someserver.com/    curl -v  http://someserver.com/

## PR checklist:
 - [x] Выставлен label с темой домашнего задания